### PR TITLE
Update Demo ExampleWindow.Drawing.cs

### DIFF
--- a/Source/SharpNav.Examples/ExampleWindow.Drawing.cs
+++ b/Source/SharpNav.Examples/ExampleWindow.Drawing.cs
@@ -215,7 +215,7 @@ namespace SharpNav.Examples
 				GL.NormalPointer(NormalPointerType.Float, 0, 0);
 			}
 
-			GL.DrawArrays(PrimitiveType.Triangles, 0, levelNumVerts);
+			GL.DrawArrays(PrimitiveType.Triangles, 0, levelNumVerts / 3);
 
 			GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
 			GL.BindBuffer(BufferTarget.ElementArrayBuffer, 0);


### PR DESCRIPTION
GL Draw with Triangles need a Triangle Count and not a vertex count.

This Remove some Garbage Triangle displayed from buffer overflow in the SharpNav Demo