### PR TITLE
Update PathCorridor.cs

### DIFF
--- a/Source/SharpNav/Crowds/PathCorridor.cs
+++ b/Source/SharpNav/Crowds/PathCorridor.cs
@@ -361,8 +361,8 @@ namespace SharpNav.Crowds
 			while (npos < pathCount && polyRef != offMeshConRef)
 			{
 				prevRef = polyRef;
-				polyRef = path[npos];
 				npos++;
+				polyRef = path[npos];			
 			}
 
 			if (npos == pathCount)


### PR DESCRIPTION
npos is now incremented before setting polyRef in PathCorridor.MoveOverOffmeshConnection
Pull request for issue #54 